### PR TITLE
Fix code block not belonging to list item

### DIFF
--- a/_posts/for-the-rest-of-us/state-monad/2024-07-01-state-monad-for-the-rest-of-us-6.md
+++ b/_posts/for-the-rest-of-us/state-monad/2024-07-01-state-monad-for-the-rest-of-us-6.md
@@ -30,23 +30,23 @@ There are in fact 2 legit answers:
 
 1. It is a **global variable**
 
-```fsharp
-let count = 1
+    ```fsharp
+    let count = 1
 
-let rec index =
-    function
-    | Leaf v -> Leaf (v, count)
-    | Node(l, r) -> failwith "Not yet implemented"
-```
+    let rec index =
+        function
+        | Leaf v -> Leaf (v, count)
+        | Node(l, r) -> failwith "Not yet implemented"
+    ```
 
 2. It is a **function parameter**:
 
-```fsharp
-let rec index count =
-    function
-    | Leaf v -> Leaf (v, count)
-    | Node(l, r) -> failwith "Not yet implemented"
-```
+    ```fsharp
+    let rec index count =
+        function
+        | Leaf v -> Leaf (v, count)
+        | Node(l, r) -> failwith "Not yet implemented"
+    ```
 
 This is a very strong design decision.
 
@@ -137,31 +137,33 @@ have placed `count` as a function parameter:
 
 1. As the first `index` parameter:
 
-```fsharp
-// Int -> Tree a -> Tree (a, Int)
-let rec index count tree=
-    match tree with
-    | Leaf v -> Leaf (v, count)
-    | Node(l, r) -> failwith "Not yet implemented"
-```
+    ```fsharp
+    // Int -> Tree a -> Tree (a, Int)
+    let rec index count tree=
+        match tree with
+        | Leaf v -> Leaf (v, count)
+        | Node(l, r) -> failwith "Not yet implemented"
+    ```
 
 2. As the second `index` parameter:
-```fsharp
-// Tree a -> Int -> Tree (a, Int)
-let rec index tree count =
-    match tree with
-    | Leaf v -> Leaf (v, count)
-    | Node(l, r) -> failwith "Not yet implemented"
-```
+
+    ```fsharp
+    // Tree a -> Int -> Tree (a, Int)
+    let rec index tree count =
+        match tree with
+        | Leaf v -> Leaf (v, count)
+        | Node(l, r) -> failwith "Not yet implemented"
+    ```
 
 3. As the parameter of a nested lambda:
-```fsharp
-// Tree a -> (Int -> Tree (a, Int))
-let rec index tree =
-    match tree with
-    | Leaf v -> fun count -> Leaf (v, count)
-    | Node(l, r) -> failwith "Not yet implemented"
-```
+
+    ```fsharp
+    // Tree a -> (Int -> Tree (a, Int))
+    let rec index tree =
+        match tree with
+        | Leaf v -> fun count -> Leaf (v, count)
+        | Node(l, r) -> failwith "Not yet implemented"
+    ```
 
 
 I would like to convince you that the 3rd option is the most


### PR DESCRIPTION
There are two lists in `state-monad-for-the-rest-of-us-6` where the code block has become a sibling of the list item, when it should be a child. This breaks the numbering and indentation:

![image](https://github.com/user-attachments/assets/427983d9-de3d-4faf-9e9e-31389fca6035)

![image](https://github.com/user-attachments/assets/50db1a49-57e4-4ab9-a85e-64769816d791)

In my experience with markdown on github, it's OK to leave a blank line between the text and the code block, as long as the code block is indented. YMMV. But `jekyll serve` on this branch appears to fix it:

![image](https://github.com/user-attachments/assets/31134b8f-79a9-4476-a02f-1f572fb872d7)

I had a quick search for other places where this may have happened and found none. Looks like just one page to fix.

HTH!

